### PR TITLE
Throw error on non-existent routes

### DIFF
--- a/src/Generators/templates/Router.js
+++ b/src/Generators/templates/Router.js
@@ -20,6 +20,8 @@
         result = this.cleanupDoubleSlashes(rootUrl + '/' + compiled);
         result = this.stripTrailingSlash(result);
         return result;
+      } else {
+        throw "Invalid route";
       }
 
     },


### PR DESCRIPTION
Previously, when .route() was called with an invalid route, it simply returned nothing, which was eventually interpreted as the root of the domain, causing the homepage to be loaded. Since calling a non-existent route is going to be a bug, it should throw an exception.
